### PR TITLE
Travis AWS Deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ deploy:
   region: eu-central-1
   access_key_id: $AWS_ACCESS_KEY_ID
   secret_access_key: $AWS_ACCESS_KEY
+  on:
+    branch: dev
 notifications:
   slack:
     secure: jvJ0e4l4YtZCJKqw46fVKOELgQvLxOXwvXiYgJ8YL36QKKcJq1qhLoRzSOwrBqLBswCrHohiafbf/hxhBAu/nYKQN4YekWzKlZXi4VJlLWOR9WpCiSHNYCv8T13Y3SKhWIF58YlWOGy0a7okAV3S8HHzfmOb2B6CirSwYtaSqPcc+LJ0ywDacP5ExVPg17bu/3+Dog6JjW6Y/yz/pVVKcErQvcCoRkk9PFFgHY4ebzj3ORA20FbZrL/BDu+VXaDj7dkUde4qeVqW9+CFs3SPeib50ZdttNLB7OeQU3MZpseSLphePwrgEfHqKMztSEtvXG5SttA3lyfxwgcajI0LctMbyGiS9rzIKij57EFH5kqFBDwwhnAtF/c0LbPkoyqZ+nmkwSU7P9z79bovOiQ3BGwtCB0MA2mYz88q5r31jBmFy05Ya1qc7sz6a6PON1fvtSCT73VFrWwCd3yRsD1weZo1OrVIIWhLULUwV9yDz77rDMhLW01I3NFL6rnqW/9RawOpK7wGujFKM7FWUOi6um51BLQGwEltopQclXH95+GBG+w+yE8t/amh+QRoIYs4WsCs/MLbAAB+65WqgelAO1gFNnPUeQ+7kk3mTWMhHwdZj27OjCJkrRugxKatcIAvsPBgnCQCR/yDwNoOH23lSfuzWbYV8DKN6+to0Z+XEsA=

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,20 @@ jdk: oraclejdk8
 script:
 - echo "Skipping Tests"
 - echo "Running Scripts"
-- ls
-- pwd
+- echo "" >> src/main/resources/application.properties
+- echo $M_TOKEN >> src/main/resources/application.properties
+- echo "Building package to deploy to AWS"
+- ./mvnw clean package -DskipTests=true
+deploy:
+  provider: elasticbeanstalk
+  skip_cleanup: true
+  app: $AWS_APP_NAME
+  env: $AWS_ENV_NAME
+  zip_file: 'target/backend-service-0.0.1-SNAPSHOT.war'
+  bucket_name: $AWS_BUCKET_NAME
+  region: eu-central-1
+  access_key_id: $AWS_ACCESS_KEY_ID
+  secret_access_key: $AWS_ACCESS_KEY
 notifications:
   slack:
     secure: jvJ0e4l4YtZCJKqw46fVKOELgQvLxOXwvXiYgJ8YL36QKKcJq1qhLoRzSOwrBqLBswCrHohiafbf/hxhBAu/nYKQN4YekWzKlZXi4VJlLWOR9WpCiSHNYCv8T13Y3SKhWIF58YlWOGy0a7okAV3S8HHzfmOb2B6CirSwYtaSqPcc+LJ0ywDacP5ExVPg17bu/3+Dog6JjW6Y/yz/pVVKcErQvcCoRkk9PFFgHY4ebzj3ORA20FbZrL/BDu+VXaDj7dkUde4qeVqW9+CFs3SPeib50ZdttNLB7OeQU3MZpseSLphePwrgEfHqKMztSEtvXG5SttA3lyfxwgcajI0LctMbyGiS9rzIKij57EFH5kqFBDwwhnAtF/c0LbPkoyqZ+nmkwSU7P9z79bovOiQ3BGwtCB0MA2mYz88q5r31jBmFy05Ya1qc7sz6a6PON1fvtSCT73VFrWwCd3yRsD1weZo1OrVIIWhLULUwV9yDz77rDMhLW01I3NFL6rnqW/9RawOpK7wGujFKM7FWUOi6um51BLQGwEltopQclXH95+GBG+w+yE8t/amh+QRoIYs4WsCs/MLbAAB+65WqgelAO1gFNnPUeQ+7kk3mTWMhHwdZj27OjCJkrRugxKatcIAvsPBgnCQCR/yDwNoOH23lSfuzWbYV8DKN6+to0Z+XEsA=

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ deploy:
   access_key_id: $AWS_ACCESS_KEY_ID
   secret_access_key: $AWS_ACCESS_KEY
   on:
-    branch: dev
+    branch: release
 notifications:
   slack:
     secure: jvJ0e4l4YtZCJKqw46fVKOELgQvLxOXwvXiYgJ8YL36QKKcJq1qhLoRzSOwrBqLBswCrHohiafbf/hxhBAu/nYKQN4YekWzKlZXi4VJlLWOR9WpCiSHNYCv8T13Y3SKhWIF58YlWOGy0a7okAV3S8HHzfmOb2B6CirSwYtaSqPcc+LJ0ywDacP5ExVPg17bu/3+Dog6JjW6Y/yz/pVVKcErQvcCoRkk9PFFgHY4ebzj3ORA20FbZrL/BDu+VXaDj7dkUde4qeVqW9+CFs3SPeib50ZdttNLB7OeQU3MZpseSLphePwrgEfHqKMztSEtvXG5SttA3lyfxwgcajI0LctMbyGiS9rzIKij57EFH5kqFBDwwhnAtF/c0LbPkoyqZ+nmkwSU7P9z79bovOiQ3BGwtCB0MA2mYz88q5r31jBmFy05Ya1qc7sz6a6PON1fvtSCT73VFrWwCd3yRsD1weZo1OrVIIWhLULUwV9yDz77rDMhLW01I3NFL6rnqW/9RawOpK7wGujFKM7FWUOi6um51BLQGwEltopQclXH95+GBG+w+yE8t/amh+QRoIYs4WsCs/MLbAAB+65WqgelAO1gFNnPUeQ+7kk3mTWMhHwdZj27OjCJkrRugxKatcIAvsPBgnCQCR/yDwNoOH23lSfuzWbYV8DKN6+to0Z+XEsA=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: java
-jdk: oraclejdk11
+jdk: oraclejdk8
 script:
 - echo "Skipping Tests"
+- echo "Running Scripts"
+- ls
+- pwd
 notifications:
   slack:
     secure: jvJ0e4l4YtZCJKqw46fVKOELgQvLxOXwvXiYgJ8YL36QKKcJq1qhLoRzSOwrBqLBswCrHohiafbf/hxhBAu/nYKQN4YekWzKlZXi4VJlLWOR9WpCiSHNYCv8T13Y3SKhWIF58YlWOGy0a7okAV3S8HHzfmOb2B6CirSwYtaSqPcc+LJ0ywDacP5ExVPg17bu/3+Dog6JjW6Y/yz/pVVKcErQvcCoRkk9PFFgHY4ebzj3ORA20FbZrL/BDu+VXaDj7dkUde4qeVqW9+CFs3SPeib50ZdttNLB7OeQU3MZpseSLphePwrgEfHqKMztSEtvXG5SttA3lyfxwgcajI0LctMbyGiS9rzIKij57EFH5kqFBDwwhnAtF/c0LbPkoyqZ+nmkwSU7P9z79bovOiQ3BGwtCB0MA2mYz88q5r31jBmFy05Ya1qc7sz6a6PON1fvtSCT73VFrWwCd3yRsD1weZo1OrVIIWhLULUwV9yDz77rDMhLW01I3NFL6rnqW/9RawOpK7wGujFKM7FWUOi6um51BLQGwEltopQclXH95+GBG+w+yE8t/amh+QRoIYs4WsCs/MLbAAB+65WqgelAO1gFNnPUeQ+7kk3mTWMhHwdZj27OjCJkrRugxKatcIAvsPBgnCQCR/yDwNoOH23lSfuzWbYV8DKN6+to0Z+XEsA=

--- a/pom.xml
+++ b/pom.xml
@@ -13,9 +13,10 @@
 	<version>0.0.1-SNAPSHOT</version>
 	<name>backend-service</name>
 	<description>Backend service for Puffnote</description>
+	<packaging>war</packaging>
 
 	<properties>
-		<java.version>11</java.version>
+		<java.version>1.8</java.version>
 	</properties>
 
 	<dependencies>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,5 @@
-# spring.data.mongodb.authentication-database= # Authentication database name.
-# spring.data.mongodb.database= # Database name.
-# spring.data.mongodb.host= # Mongo server host. Cannot be set with URI.
-# spring.data.mongodb.password= # Login password of the mongo server. Cannot be set with URI.
-# spring.data.mongodb.port= # Mongo server port. Cannot be set with URI.
-# spring.data.mongodb.uri=mongodb://localhost/test # Mongo database URI. Cannot be set with host, port and credentials.
-# spring.data.mongodb.username= # Login user of the mongo server. Cannot be set with URI.
+spring:
+  autoconfigure:
+    exclude: org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration
 logging.file= application.log
+server.port=5000


### PR DESCRIPTION
### What has been changed?
- Travis now deploys packaged war file automatically to AWS on **release** branch **only**.
- JDK change to 1.8/8 to support AWS Elastic Beanstalk
- Automatic MongoDB configuration disabled. Auto config was pointing by default to localhost and 27017. Now via Travis, MongoDB config is injected to application.properties securely before packaging.

### How was it tested?
- Application successfully built and run locally.
- Travis scripts run successfully.
- Automatic deploy to AWS tested successfully initially on **dev** branch.