### PR TITLE
Added dev and prod Spring profiles. Travis now injects pre-deploy prod data.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,14 @@ language: java
 jdk: oraclejdk8
 script:
 - echo "Skipping Tests"
-- echo "Running Scripts"
-- echo "" >> src/main/resources/application.properties
-- echo $M_TOKEN >> src/main/resources/application.properties
+- echo "Running Prod Level Scripts"
+- echo "" >> src/main/resources/application-prod.properties
+- echo $M_TOKEN >> src/main/resources/application-prod.properties
+- echo $M_DB >> src/main/resources/application-prod.properties
+- echo $AU_JTOK_SEC >> src/main/resources/application-prod.properties
+- echo $AU_JTOK_EX >> src/main/resources/application-prod.properties
 - echo "Building package to deploy to AWS"
-- ./mvnw clean package -DskipTests=true
+- ./mvnw clean package -DskipTests=true -Pprod
 deploy:
   provider: elasticbeanstalk
   skip_cleanup: true

--- a/pom.xml
+++ b/pom.xml
@@ -89,6 +89,31 @@
 				<artifactId>spring-boot-maven-plugin</artifactId>
 			</plugin>
 		</plugins>
+
+		<resources>
+			<resource>
+				<directory>src/main/resources</directory>
+				<filtering>true</filtering>
+			</resource>
+		</resources>
 	</build>
+
+	<profiles>
+		<profile>
+			<id>dev</id>
+			<activation>
+				<activeByDefault>true</activeByDefault>
+			</activation>
+			<properties>
+				<spring.profiles.active>dev</spring.profiles.active>
+			</properties>
+		</profile>
+		<profile>
+			<id>prod</id>
+			<properties>
+				<spring.profiles.active>prod</spring.profiles.active>
+			</properties>
+		</profile>
+	</profiles>
 
 </project>

--- a/src/main/resources/application-dev.properties
+++ b/src/main/resources/application-dev.properties
@@ -1,0 +1,11 @@
+spring:
+  autoconfigure:
+    exclude: org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration
+logging.file= application.log
+server.port=5000
+logging.level.org.springframework.security=DEBUG
+auth.jwt.type=JWT
+auth.jwt.issuer=Abcd
+auth.jwt.audience=Abcd-app
+auth.jwt.secret=u7w!z%C*F-JaNdRgUkXp2s5v8y/A?D(G+KbPeShVmYq3t6w9z$C&E)H@McQfTjWn
+auth.jwt.expiryms=43200000

--- a/src/main/resources/application-prod.properties
+++ b/src/main/resources/application-prod.properties
@@ -2,5 +2,7 @@ spring:
   autoconfigure:
     exclude: org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration
 logging.file= application.log
-spring.profiles.active=@spring.profiles.active@
-server.port=3000
+server.port=5000
+auth.jwt.type=JWT
+auth.jwt.issuer=CollabHQ
+auth.jwt.audience=Collab-App


### PR DESCRIPTION
### What has been changed?
- dev and prod profiles added to Spring. dev used by default.
- Modified travis to add pre-deploy prod data

### How was it tested?
- By default, application-dev.properties used as expected
- Passing -Pprod on mvn package works as expected and makes use of the prod profile